### PR TITLE
Added incrementBrightness support for groups

### DIFF
--- a/huemagic/hue-group.js
+++ b/huemagic/hue-group.js
@@ -462,6 +462,18 @@ module.exports = function(RED)
 						patchObject["bri"] = msg.payload.brightnessLevel;
 					}
 				}
+				else if(typeof msg.payload != 'undefined' && typeof msg.payload.incrementBrightness != 'undefined')
+				{
+					let incrementBy = (isNaN(msg.payload.incrementBrightness)) ? 10 : msg.payload.incrementBrightness;
+
+					if ((incrementBy > 100) || (incrementBy < -100))
+					{
+						scope.error("Invalid incrementBrightness setting. Only -100% to 100% allowed");
+						return false;
+					}
+
+					patchObject["bri_inc"] = Math.round((254/100)*incrementBy);
+				}
 
 				// SET HUMAN READABLE COLOR OR RANDOM
 				if(typeof msg.payload != 'undefined' && typeof msg.payload.color != 'undefined')

--- a/huemagic/locales/de/hue-group.html
+++ b/huemagic/locales/de/hue-group.html
@@ -27,6 +27,7 @@ Neben dem einfachen Ein- und Ausschalten, stehen Ihnen auch viele weitere Option
 : toggle (boolean | any) : Wechselt zwischen Ein- und Ausschalten, je nachdem, wie der vorherige Zustand der Gruppe war
 : brightness (int | string) : Prozentualer Wert der Lichthelligkeit (0-100) oder ein String mit dem Wert `auto`, um die Lichthelligkeit automatisch auf Basis der aktuellen Uhrzeit einzustellen
 : brightnessLevel (int) : Nummerischer Wert der Lichthelligkeit (0-254)
+: incrementBrightness (int): Prozentualer Wert einer relativen Helligkeitsänderung (-100% bis +100%). Default ist +10%.
 : color (string) : `random`, um eine zufällige Farbe einzustellen oder einen englischen Farbnamen (z. B. `red`)
 : hex (string) : Farbwert in Hexadezimal in Form eines Strings
 : rgb (array[0,0,0]) : Farbwert im RGB-Format in Form eines Arrays

--- a/huemagic/locales/en-US/hue-group.html
+++ b/huemagic/locales/en-US/hue-group.html
@@ -27,6 +27,7 @@ In addition to simply switching it on and off, there are also many other options
 : toggle (boolean | any): Toggles between switching on and off, depending on the previous status of the group
 : brightness (int | string): Percentage value of the light brightness (0-100) or a string with the value `auto` to automatically set the light brightness based on the current time
 : brightnessLevel (int): Numerical value of the light brightness (0-254)
+: incrementBrightness (int): Percentage value of a relative brightness change. Valid range is from -100% to +100%, default is +10%
 : color (string): `random` to set a random color or an English color name (e.g. `red`)
 : hex (string): Color value in hexadecimal in the form of a string
 : rgb (array [0,0,0]): Color value in RGB format in the form of an array


### PR DESCRIPTION
Hi folks ..

I have added the missing incrementBrightness support for groups which is reported in issue https://github.com/Foddy/node-red-contrib-huemagic/issues/380. In my opinion it is mandatory when huemagic shall be used to connect KNX switches to Philips Hue. I have done it in the following way:

- When the user wants to dimm the lights, he has to presses and hold the KNX switch, this causes a message on the bus which is received by node-red.
- A incrementBrightness (+/-100%, depending on the direction) command with a significant transitionTime (4 seconds) is invoked.
- The lights start to dimm.
- When the user wants to stop the process he releases the switch, this causes a further "stop" message on the bus which is also received by node-red.
- A incrementBrightness (value = 0) command is invoked which stops the currently ongoing transition.

This is the best way to get this done because:
1. Only two hue api calls are needed
2. The brightness transition itself is flawless as is done inside of the hue system.

But for this approach incrementBrightness support is mandatory .. see also the [official v1 api docs](https://developers.meethue.com/develop/hue-api/groupds-api/#set-group-attr) on the bri_inc argument. I have found it while searching for a proper way to get the task done as my other attempts have been suboptimal.

If there is a good reason to get the task done in a different way, let me know ;-)

br J.