### PR TITLE
Add HTTPS Protocol Support for Philips Hue Bridge Pro Connections

### DIFF
--- a/PUBLICATION_NPM.md
+++ b/PUBLICATION_NPM.md
@@ -1,0 +1,162 @@
+# Guide de publication sur npm
+
+Ce guide vous explique comment publier votre fork de `node-red-contrib-huemagic` sur npm pour pouvoir l'utiliser en production.
+
+## Prérequis
+
+1. **Compte npm** : Si vous n'avez pas encore de compte npm, créez-en un sur [https://www.npmjs.com/signup](https://www.npmjs.com/signup)
+
+2. **Node.js et npm installés** : Vérifiez que vous avez Node.js et npm installés :
+   ```bash
+   node --version
+   npm --version
+   ```
+
+## Étapes de publication
+
+### 1. Se connecter à npm
+
+Ouvrez un terminal dans le répertoire du projet et connectez-vous à npm :
+
+```bash
+npm login
+```
+
+Vous devrez entrer :
+- Votre nom d'utilisateur npm
+- Votre mot de passe
+- Votre adresse email
+
+### 2. Vérifier la configuration du package
+
+Le fichier `package.json` a été configuré avec :
+- **Nom du package** : `node-red-contrib-huemagic-napadelice` (nom unique pour éviter les conflits)
+- **Version** : `4.2.8`
+- **Auteur** : napadelice
+- **Repository** : Votre fork GitHub
+
+### 3. Vérifier que tout est prêt
+
+Avant de publier, vérifiez que :
+- Tous vos changements sont commités
+- Le package.json est correct
+- Vous êtes dans le bon répertoire
+
+```bash
+# Vérifier le contenu du package.json
+cat package.json
+
+# Vérifier que vous êtes connecté
+npm whoami
+```
+
+### 4. Tester la publication (optionnel mais recommandé)
+
+Vous pouvez tester votre package localement avant de le publier :
+
+```bash
+# Créer un package local
+npm pack
+
+# Cela créera un fichier .tgz que vous pouvez tester
+```
+
+### 5. Publier sur npm
+
+Une fois prêt, publiez votre package :
+
+```bash
+npm publish
+```
+
+Si vous utilisez un scope (nom commençant par `@`), utilisez :
+
+```bash
+npm publish --access public
+```
+
+### 6. Vérifier la publication
+
+Après la publication, vérifiez que votre package est bien disponible :
+
+```bash
+npm view node-red-contrib-huemagic-napadelice
+```
+
+Vous pouvez aussi le voir sur le site npm : [https://www.npmjs.com/package/node-red-contrib-huemagic-napadelice](https://www.npmjs.com/package/node-red-contrib-huemagic-napadelice)
+
+## Utilisation dans Node-RED
+
+Une fois publié, vous pouvez installer votre package dans Node-RED de deux façons :
+
+### Méthode 1 : Via l'interface Node-RED
+
+1. Ouvrez Node-RED
+2. Allez dans le menu (☰) > **Manage palette**
+3. Cliquez sur l'onglet **Install**
+4. Recherchez `node-red-contrib-huemagic-napadelice`
+5. Cliquez sur **Install**
+
+### Méthode 2 : Via la ligne de commande
+
+```bash
+cd ~/.node-red  # ou le répertoire de votre installation Node-RED
+npm install node-red-contrib-huemagic-napadelice
+```
+
+Puis redémarrez Node-RED.
+
+## Mettre à jour le package
+
+Quand vous voulez publier une nouvelle version :
+
+1. **Mettez à jour la version** dans `package.json` :
+   ```bash
+   npm version patch  # pour 4.2.8 -> 4.2.9
+   # ou
+   npm version minor  # pour 4.2.8 -> 4.3.0
+   # ou
+   npm version major  # pour 4.2.8 -> 5.0.0
+   ```
+
+2. **Commitez et poussez** les changements :
+   ```bash
+   git add package.json
+   git commit -m "Bump version to X.X.X"
+   git push
+   ```
+
+3. **Publiez** :
+   ```bash
+   npm publish
+   ```
+
+## Notes importantes
+
+- **Nom unique** : Le nom `node-red-contrib-huemagic-napadelice` est unique et vous appartient. Si vous préférez un autre nom, modifiez-le dans `package.json` avant la première publication.
+
+- **Version** : Assurez-vous d'incrémenter la version à chaque publication pour que les utilisateurs puissent obtenir les mises à jour.
+
+- **Licence** : Le package conserve la licence Apache-2.0 du projet original, ce qui est conforme pour un fork.
+
+- **Dépendances** : Toutes les dépendances sont déjà listées dans `package.json` et seront installées automatiquement lors de l'installation du package.
+
+## Dépannage
+
+### Erreur : "You do not have permission to publish"
+- Vérifiez que vous êtes connecté avec `npm whoami`
+- Vérifiez que le nom du package n'est pas déjà pris par quelqu'un d'autre
+
+### Erreur : "Package name too similar"
+- Choisissez un nom plus différent dans `package.json`
+
+### Le package n'apparaît pas dans Node-RED
+- Assurez-vous que le nom du package commence par `node-red-contrib-` pour qu'il soit reconnu par Node-RED
+- Redémarrez Node-RED après l'installation
+
+## Support
+
+Pour toute question ou problème, vous pouvez :
+- Ouvrir une issue sur votre repository GitHub
+- Consulter la documentation npm : [https://docs.npmjs.com/](https://docs.npmjs.com/)
+

--- a/WORKFLOW_PUBLICATION.md
+++ b/WORKFLOW_PUBLICATION.md
@@ -1,0 +1,68 @@
+# Workflow de publication recommandé
+
+## État actuel
+- Vous êtes sur la branche `feature/bridgepro` avec des améliorations
+- Des modifications du `package.json` sont en attente
+- La branche `master` n'a pas encore les changements de `feature/bridgepro`
+
+## Étapes recommandées avant publication
+
+### Option 1 : Merger dans master puis publier (RECOMMANDÉ)
+
+```bash
+# 1. Retourner sur feature/bridgepro
+git checkout feature/bridgepro
+
+# 2. Commiter les modifications du package.json et du guide
+git add package.json PUBLICATION_NPM.md
+git commit -m "Configure package for npm publication with napadelice branding"
+
+# 3. Pousser les changements
+git push origin feature/bridgepro
+
+# 4. Basculer sur master
+git checkout master
+
+# 5. Merger feature/bridgepro dans master
+git merge feature/bridgepro
+
+# 6. Pousser master
+git push origin master
+
+# 7. Publier sur npm depuis master
+npm login
+npm publish
+```
+
+### Option 2 : Publier directement depuis feature/bridgepro (si vous préférez)
+
+```bash
+# 1. Commiter les modifications
+git add package.json PUBLICATION_NPM.md
+git commit -m "Configure package for npm publication with napadelice branding"
+
+# 2. Pousser les changements
+git push origin feature/bridgepro
+
+# 3. Publier depuis feature/bridgepro
+npm login
+npm publish
+```
+
+## Pourquoi merger dans master ?
+
+✅ **Avantages** :
+- Master reste la branche de référence stable
+- Facilite la maintenance future
+- Meilleure pratique Git
+- Les autres développeurs savent où trouver la version publiée
+
+⚠️ **Si vous publiez depuis feature/bridgepro** :
+- La branche de développement devient la version publiée
+- Peut créer de la confusion plus tard
+- Moins standard mais fonctionnel
+
+## Recommandation
+
+**Je recommande l'Option 1** : merger dans master puis publier. Cela garde votre workflow propre et professionnel.
+

--- a/huemagic/hue-bridge-config.html
+++ b/huemagic/hue-bridge-config.html
@@ -4,6 +4,13 @@
 		<input type="text" id="node-config-input-name" style="width: calc(100% - 105px)">
 	</div>
 	<div class="form-row">
+		<label for="node-config-input-protocol"><i class="fa fa-lock"></i> <span>Protocole</span></label>
+		<select id="node-config-input-protocol" style="width: calc(100% - 105px)">
+			<option value="http">HTTP</option>
+			<option value="https">HTTPS</option>
+		</select>
+	</div>
+	<div class="form-row">
 		<label for="node-config-input-bridge"><i class="fa fa-server"></i> Bridge IP</label>
 		<div style="display: inline-flex; width: calc(100% - 105px)">
             <div id="input-select-toggle" style="flex-grow: 1;">
@@ -49,6 +56,7 @@
 		color: '#c7d8d8',
 		defaults: {
 			name: { value:"Hue Bridge", required: true },
+			protocol: { value: "http" },
 			bridge: { value:"", required: true },
 			key: { value:"", required: true },
 			worker: { value: 10, required: true, validate: function(v) {
@@ -148,10 +156,11 @@
 					// TRIGGER SEARCHING NOTIFICATION
 					var notification = RED.notify(scope._("hue-bridge-config.config.connecting"), { type: "compact", modal: true, fixed: true });
 
+					var protocol = $('#node-config-input-protocol').val() || 'http';
 					$.ajax({
 						url: 'hue/name',
 						type: "GET",
-						data: { ip: currentBridgeIP },
+						data: { ip: currentBridgeIP, protocol: protocol },
 						timeout: 3000
 					})
 					.done( function(data)
@@ -195,9 +204,10 @@
 
 					RED.notify(scope._("hue-bridge-config.config.new-user-press"));
 
+					var protocol = $('#node-config-input-protocol').val() || 'http';
 					setTimeout(function()
 					{
-						$.get('hue/register', { ip: $('#node-config-input-bridge').val() } )
+						$.get('hue/register', { ip: $('#node-config-input-bridge').val(), protocol: protocol } )
 						.done( function(data)
 						{
 							if(data == "error")

--- a/huemagic/hue-bridge-config.js
+++ b/huemagic/hue-bridge-config.js
@@ -845,11 +845,11 @@ module.exports = function(RED)
 	RED.httpAdmin.get('/hue/resources', function(req, res, next)
 	{
 		const targetType = req.query.type;
+		var protocol = req.query.protocol || 'http';
 
 		// GET ALL RULES
 		if(targetType == "rule")
 		{
-			var protocol = req.query.protocol || 'http';
 			API.request({ config: { bridge: req.query.bridge, key: req.query.key, protocol: protocol }, resource: "/rules", version: 1 })
 			.then(function(rules)
 			{
@@ -878,7 +878,6 @@ module.exports = function(RED)
 		// GET ALL OTHER RESOURCES
 		else
 		{
-			var protocol = req.query.protocol || 'http';
 			API.request({ config: { bridge: req.query.bridge, key: req.query.key, protocol: protocol }, resource: "all" })
 			.then(function(allResources)
 			{

--- a/huemagic/hue-bridge-config.js
+++ b/huemagic/hue-bridge-config.js
@@ -770,7 +770,8 @@ module.exports = function(RED)
 	    }
 	    else
 	    {
-			API.init({ config: { bridge: req.query.ip, key: "huemagic" } })
+			var protocol = req.query.protocol || 'http';
+			API.init({ config: { bridge: req.query.ip, key: "huemagic", protocol: protocol } })
 			.then(function(bridge) {
 				res.end(bridge.name);
 			})
@@ -790,17 +791,37 @@ module.exports = function(RED)
 		}
 		else
 		{
-			axios({
+			// Determine protocol (default HTTP for compatibility)
+			var protocol = req.query.protocol || 'http';
+			
+			// Determine port: if already specified in IP, keep it, otherwise use default port
+			var bridgeUrl = req.query.ip;
+			if (bridgeUrl.indexOf(':') === -1) {
+				// No port specified, add default port according to protocol
+				if (protocol === 'https') {
+					bridgeUrl = bridgeUrl + ':443';
+				} else {
+					bridgeUrl = bridgeUrl + ':80';
+				}
+			}
+			
+			var axiosConfig = {
 				"method": "POST",
-				"url": "http://"+req.query.ip+"/api",
-				"httpsAgent": new https.Agent({ rejectUnauthorized: false }),
+				"url": protocol + "://" + bridgeUrl + "/api",
 				"headers": {
 					"Content-Type": "application/json; charset=utf-8"
 				},
 				"data": {
 					"devicetype": "HueMagic for Node-RED (" + Math.floor((Math.random() * 100) + 1) + ")"
 				}
-			})
+			};
+			
+			// Add httpsAgent only for HTTPS
+			if (protocol === 'https') {
+				axiosConfig["httpsAgent"] = new https.Agent({ rejectUnauthorized: false });
+			}
+			
+			axios(axiosConfig)
 			.then(function(response)
 			{
 				var bridge = response.data;
@@ -828,7 +849,8 @@ module.exports = function(RED)
 		// GET ALL RULES
 		if(targetType == "rule")
 		{
-			API.request({ config: { bridge: req.query.bridge, key: req.query.key }, resource: "/rules", version: 1 })
+			var protocol = req.query.protocol || 'http';
+			API.request({ config: { bridge: req.query.bridge, key: req.query.key, protocol: protocol }, resource: "/rules", version: 1 })
 			.then(function(rules)
 			{
 				let targetRules = {};
@@ -856,7 +878,8 @@ module.exports = function(RED)
 		// GET ALL OTHER RESOURCES
 		else
 		{
-			API.request({ config: { bridge: req.query.bridge, key: req.query.key }, resource: "all" })
+			var protocol = req.query.protocol || 'http';
+			API.request({ config: { bridge: req.query.bridge, key: req.query.key, protocol: protocol }, resource: "all" })
 			.then(function(allResources)
 			{
 				return API.processResources(allResources);

--- a/huemagic/hue-brightness.html
+++ b/huemagic/hue-brightness.html
@@ -108,7 +108,7 @@
                 var notification = RED.notify(scope._("hue-brightness.config.searching"), { type: "compact", modal: true, fixed: true });
 
                 // GET THE SENSORS
-                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "motion" })
+                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "motion" })
                 .done( function(data) {
                     var allResources = JSON.parse(data);
                     allResources = sortResourcesBy('name', allResources);

--- a/huemagic/hue-buttons.html
+++ b/huemagic/hue-buttons.html
@@ -153,7 +153,7 @@
                 var notification = RED.notify(scope._("hue-buttons.config.searching"), { type: "compact", modal: true, fixed: true });
 
                 // GET THE SENSORS
-                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "button" })
+                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "button" })
                 .done( function(data) {
                     var allResources = JSON.parse(data);
                     allResources = sortResourcesBy('name', allResources);

--- a/huemagic/hue-dial.html
+++ b/huemagic/hue-dial.html
@@ -111,7 +111,7 @@
                 });
 
                 // GET THE dialS
-                $.get('hue/resources', {bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "button"})
+                $.get('hue/resources', {bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "button"})
                     .done(function (data) {
                         var allResources = JSON.parse(data);
                         allResources = sortResourcesBy('name', allResources);

--- a/huemagic/hue-group.html
+++ b/huemagic/hue-group.html
@@ -108,7 +108,7 @@
                 var notification = RED.notify(scope._("hue-group.config.searching"), { type: "compact", modal: true, fixed: true });
 
                 // GET THE GROUPS
-                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "group" })
+                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "group" })
                 .done( function(data) {
                     var allResources = JSON.parse(data);
                     allResources = sortResourcesBy('name', allResources);

--- a/huemagic/hue-light.html
+++ b/huemagic/hue-light.html
@@ -115,7 +115,7 @@
                 var notification = RED.notify(scope._("hue-light.config.searching"), { type: "compact", modal: true, fixed: true });
 
                 // GET THE LIGHTS
-                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "light" })
+                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "light" })
                 .done( function(data) {
                     var allResources = JSON.parse(data);
                     allResources = sortResourcesBy('name', allResources);

--- a/huemagic/hue-motion.html
+++ b/huemagic/hue-motion.html
@@ -108,7 +108,7 @@
                 var notification = RED.notify(scope._("hue-motion.config.searching"), { type: "compact", modal: true, fixed: true });
 
                 // GET THE SENSORS
-                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "motion" })
+                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "motion" })
                 .done( function(data) {
                     var allResources = JSON.parse(data);
                     allResources = sortResourcesBy('name', allResources);

--- a/huemagic/hue-rules.html
+++ b/huemagic/hue-rules.html
@@ -108,7 +108,7 @@
                 var notification = RED.notify(scope._("hue-rules.config.searching"), { type: "compact", modal: true, fixed: true });
 
                 // GET THE SENSORS
-                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "rule" })
+                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "rule" })
                 .done( function(data) {
                     var allResources = JSON.parse(data);
                     allResources = sortResourcesBy('name', allResources);

--- a/huemagic/hue-scene.html
+++ b/huemagic/hue-scene.html
@@ -94,7 +94,7 @@
                 var notification = RED.notify(scope._("hue-rules.config.searching"), { type: "compact", modal: true, fixed: true });
 
                 // GET THE SCENES
-                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "scene" })
+                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "scene" })
                 .done( function(data) {
                     var allResources = JSON.parse(data);
                     allResources = sortResourcesBy('name', allResources);

--- a/huemagic/hue-temperature.html
+++ b/huemagic/hue-temperature.html
@@ -108,7 +108,7 @@
                 var notification = RED.notify(scope._("hue-temperature.config.searching"), { type: "compact", modal: true, fixed: true });
 
                 // GET THE SENSORS
-                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, type: "temperature" })
+                $.get('hue/resources', { bridge: bridgeConfig.bridge, key: bridgeConfig.key, protocol: bridgeConfig.protocol || 'http', type: "temperature" })
                 .done( function(data) {
                     var allResources = JSON.parse(data);
                     allResources = sortResourcesBy('name', allResources);

--- a/package.json
+++ b/package.json
@@ -1,20 +1,19 @@
 {
-  "name": "node-red-contrib-huemagic-fork",
+  "name": "node-red-contrib-huemagic-napadelice",
   "version": "4.2.8",
   "description": "Philips Hue node to control bridges, lights, groups, scenes, rules, taps, tap dial, switches, buttons, motion sensors, temperature sensors and Lux sensors using Node-RED.",
-  "author": "foddy, mauricedominic",
-  "homepage": "https://github.com/mauricedominic/node-red-contrib-huemagic",
+  "author": "napadelice",
+  "homepage": "https://github.com/BordetNicolas/node-red-contrib-huemagic",
   "license": "Apache-2.0",
   "maintainers": [
-    "Foddy Botosakis <github@foddys.com>",
-    "MauriceDominic"
+    "napadelice"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mauricedominic/node-red-contrib-huemagic.git"
+    "url": "https://github.com/BordetNicolas/node-red-contrib-huemagic.git"
   },
   "bugs": {
-    "url": "https://github.com/mauricedominic/node-red-contrib-huemagic/issues"
+    "url": "https://github.com/BordetNicolas/node-red-contrib-huemagic/issues"
   },
   "keywords": [
     "node-red",


### PR DESCRIPTION
## Add HTTPS Protocol Support for Philips Hue Bridge Connections

This PR adds support for HTTPS protocol when connecting to Philips Hue bridges, while maintaining full backward compatibility with existing HTTP connections.

### Changes Overview

#### User Interface
- Added protocol selector dropdown in the Hue Bridge configuration node
- Users can now choose between HTTP (default) and HTTPS protocols
- Bridge IP field supports optional port specification (e.g., `192.168.1.100:443`)

#### Backend Implementation

**New Helper Functions** (`huemagic/utils/api.js`):
- `normalizeBridgeUrl()`: Automatically adds default ports (80 for HTTP, 443 for HTTPS) when not specified
- `buildBridgeUrl()`: Constructs complete URLs with the appropriate protocol prefix

**Protocol Handling**:
- All API requests now support both HTTP and HTTPS protocols
- HTTPS connections use `https.Agent` with `rejectUnauthorized: false` to handle self-signed certificates from Hue bridges
- EventSource (SSE) connections properly handle HTTPS with appropriate SSL options
- Default protocol remains HTTP for backward compatibility

**Modified Files**:
- `huemagic/hue-bridge-config.html`: Added protocol selector UI element
- `huemagic/hue-bridge-config.js`: 
  - Updated bridge registration endpoint to support protocol selection
  - Added protocol parameter handling in bridge name retrieval
  - Implemented automatic port detection and assignment
- `huemagic/utils/api.js`:
  - Added URL normalization and building helpers
  - Updated `init()`, `request()`, and `subscribe()` methods to support HTTPS
  - Added HTTPS agent configuration for secure connections

### Technical Details

- **Port Handling**: If a port is already specified in the bridge IP address, it is preserved. Otherwise, default ports are automatically assigned (80 for HTTP, 443 for HTTPS)
- **SSL Certificate Validation**: HTTPS connections disable certificate validation (`rejectUnauthorized: false`) to support self-signed certificates commonly used by Hue bridges
- **Backward Compatibility**: All existing configurations continue to work with HTTP as the default protocol

### Testing

- [x] HTTP connections continue to work as before
- [x] HTTPS connections work with default port (443)
- [x] Custom ports are preserved when specified
- [x] Bridge registration works with both protocols
- [x] EventSource (SSE) connections work with HTTPS
- [x] All existing nodes maintain compatibility

### Breaking Changes

None. This is a fully backward-compatible enhancement.

